### PR TITLE
Added support for ssh-xmss

### DIFF
--- a/modules/dns/dns_record_edit.php
+++ b/modules/dns/dns_record_edit.php
@@ -127,8 +127,8 @@ if ($type == 'sshfp') {
     1 => "RSA",
     2 => "DSA",
     3 => "ECDSA",
-    4 => "ED25519" );
-
+    4 => "ED25519"
+    5 => "XMSS");
     $option="";
     foreach ($algs as $key => $alg) {
         $option .= '<option value="'.$key.'" ';


### PR DESCRIPTION
- Add xmss according to RFC8391 in SSHFP dns records
- Draft Recommendations: https://tools.ietf.org/html/draft-mu-curdle-ssh-xmss-00
- Done during IETF 106 Hackathon